### PR TITLE
#953 Add Biome for linting and formatting

### DIFF
--- a/packages/components/biome.json
+++ b/packages/components/biome.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": {
+        "recommended": true,
+        "noStaticElementInteractions": "off",
+        "useKeyWithClickEvents": "off"
+      },
+      "complexity": {
+        "recommended": true
+      },
+      "correctness": {
+        "recommended": true
+      },
+      "performance": {
+        "recommended": true
+      },
+      "security": {
+        "recommended": true
+      },
+      "style": {
+        "recommended": true
+      },
+      "suspicious": {
+        "recommended": true
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "es5"
+    }
+  }
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,6 +30,12 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "type-check": "tsc --noEmit",
+    "lint": "biome lint src",
+    "lint:fix": "biome lint --write src",
+    "format": "biome format --write src",
+    "format:check": "biome format src",
+    "check": "biome check src",
+    "check:fix": "biome check --write src",
     "storybook": "storybook dev -p 6006 --config-dir .storybook",
     "build-storybook": "storybook build --config-dir .storybook"
   },
@@ -38,6 +44,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.11",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/react": "^8.6.15",

--- a/packages/components/src/article/SeriesNav.stories.tsx
+++ b/packages/components/src/article/SeriesNav.stories.tsx
@@ -76,7 +76,11 @@ export const FirstInSeries: Story = {
     series: 'Algorithm Design',
     currentOrder: 1,
     posts: [
-      { slug: 'intro-algorithms', title: 'Introduction to Algorithms', order: 1 },
+      {
+        slug: 'intro-algorithms',
+        title: 'Introduction to Algorithms',
+        order: 1,
+      },
       { slug: 'sorting-algorithms', title: 'Sorting Algorithms', order: 2 },
       { slug: 'graph-algorithms', title: 'Graph Algorithms', order: 3 },
     ],
@@ -88,7 +92,11 @@ export const LastInSeries: Story = {
     series: 'Algorithm Design',
     currentOrder: 3,
     posts: [
-      { slug: 'intro-algorithms', title: 'Introduction to Algorithms', order: 1 },
+      {
+        slug: 'intro-algorithms',
+        title: 'Introduction to Algorithms',
+        order: 1,
+      },
       { slug: 'sorting-algorithms', title: 'Sorting Algorithms', order: 2 },
       { slug: 'graph-algorithms', title: 'Graph Algorithms', order: 3 },
     ],

--- a/packages/components/src/article/SeriesNav.tsx
+++ b/packages/components/src/article/SeriesNav.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 
 export interface SeriesNavProps {
   series: string;
@@ -27,9 +27,20 @@ export interface SeriesNavProps {
  * />
  * ```
  */
-export const SeriesNav: React.FC<SeriesNavProps> = ({ series, currentOrder, posts }) => {
+export const SeriesNav: React.FC<SeriesNavProps> = ({
+  series,
+  currentOrder,
+  posts,
+}) => {
   return (
-    <nav style={{ padding: '1rem', backgroundColor: '#f5f5f5', borderRadius: '4px', marginBottom: '2rem' }}>
+    <nav
+      style={{
+        padding: '1rem',
+        backgroundColor: '#f5f5f5',
+        borderRadius: '4px',
+        marginBottom: '2rem',
+      }}
+    >
       <h3 style={{ marginTop: 0 }}>Series: {series}</h3>
       {posts && posts.length > 0 ? (
         <ol>
@@ -45,7 +56,9 @@ export const SeriesNav: React.FC<SeriesNavProps> = ({ series, currentOrder, post
           ))}
         </ol>
       ) : (
-        <p><em>No posts in this series yet.</em></p>
+        <p>
+          <em>No posts in this series yet.</em>
+        </p>
       )}
     </nav>
   );

--- a/packages/components/src/article/TagList.stories.tsx
+++ b/packages/components/src/article/TagList.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { TagList } from './TagList';
 import { fn } from '@storybook/test';
+import { TagList } from './TagList';
 
 const meta = {
   title: 'Article/TagList',

--- a/packages/components/src/article/TagList.tsx
+++ b/packages/components/src/article/TagList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 
 export interface TagListProps {
   tags: string[];

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,7 +1,6 @@
 // Main export file for @chirashi/components
 
-// Re-export all MDX components
-export * from './mdx';
-
 // Re-export all article components
 export * from './article';
+// Re-export all MDX components
+export * from './mdx';

--- a/packages/components/src/mdx/Flashcard.stories.tsx
+++ b/packages/components/src/mdx/Flashcard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Flashcard, FlashcardFront, FlashcardBack } from './Flashcard';
+import { Flashcard, FlashcardBack, FlashcardFront } from './Flashcard';
 
 const meta = {
   title: 'MDX/Flashcard',

--- a/packages/components/src/mdx/Visualizer.tsx
+++ b/packages/components/src/mdx/Visualizer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 
 export interface VisualizerProps {
   type: 'bubble-sort' | 'quick-sort' | 'merge-sort' | 'binary-tree';
@@ -16,14 +16,28 @@ export interface VisualizerProps {
  * <Visualizer type="bubble-sort" data={[5, 2, 8, 1, 9]} speed={500} />
  * ```
  */
-export const Visualizer: React.FC<VisualizerProps> = ({ type, data, speed }) => {
+export const Visualizer: React.FC<VisualizerProps> = ({
+  type,
+  data,
+  speed,
+}) => {
   return (
-    <div style={{ padding: '1rem', border: '1px dashed #ccc', borderRadius: '4px' }}>
-      <p><strong>Visualizer Placeholder</strong></p>
+    <div
+      style={{
+        padding: '1rem',
+        border: '1px dashed #ccc',
+        borderRadius: '4px',
+      }}
+    >
+      <p>
+        <strong>Visualizer Placeholder</strong>
+      </p>
       <p>Type: {type}</p>
       {data && <p>Data: [{data.join(', ')}]</p>}
       {speed && <p>Speed: {speed}ms</p>}
-      <p><em>Visualization will be implemented in future phases.</em></p>
+      <p>
+        <em>Visualization will be implemented in future phases.</em>
+      </p>
     </div>
   );
 };

--- a/packages/components/src/mdx/index.ts
+++ b/packages/components/src/mdx/index.ts
@@ -1,10 +1,11 @@
 // MDX component exports
-export { Visualizer, type VisualizerProps } from './Visualizer';
+
 export {
   Flashcard,
-  FlashcardFront,
   FlashcardBack,
-  type FlashcardProps,
-  type FlashcardFrontProps,
   type FlashcardBackProps,
+  FlashcardFront,
+  type FlashcardFrontProps,
+  type FlashcardProps,
 } from './Flashcard';
+export { Visualizer, type VisualizerProps } from './Visualizer';


### PR DESCRIPTION
## Summary
Adds Biome to @chirashi/components - a faster, simpler alternative to ESLint + Prettier.

### Why Biome?
- **Single tool** replaces both ESLint and Prettier
- **10-100x faster** than ESLint + Prettier
- **Less configuration** - simpler setup
- **Better DX** - instant feedback

### Configuration
- **Linting**: All recommended rules enabled
- **Formatting**: Single quotes, semicolons, 80 char width
- **Auto-organize imports**: Alphabetically sorted
- **A11y**: Enabled (some rules disabled for placeholder components)

### Scripts Added
```bash
npm run check --workspace=@chirashi/components          # Lint + format check
npm run check:fix --workspace=@chirashi/components      # Auto-fix all issues
npm run lint --workspace=@chirashi/components           # Lint only
npm run lint:fix --workspace=@chirashi/components       # Auto-fix lint
npm run format --workspace=@chirashi/components         # Format code
npm run format:check --workspace=@chirashi/components   # Check formatting
```

### Auto-fixes Applied
- Import type optimization
- Code formatting
- Import organization
- Consistent style

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)