### PR TITLE
Update Dependabot config for monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,55 +1,86 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "20:00"
-  open-pull-requests-limit: 10
-  reviewers:
-  - iray-tno
-  ignore:
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-  - dependency-name: react-redux
-    versions:
-    - 7.2.2
-    - 7.2.3
-  - dependency-name: gatsby
-    versions:
-    - 2.31.1
-    - 2.32.0
-    - 2.32.10
-    - 2.32.11
-    - 2.32.2
-    - 2.32.3
-    - 2.32.4
-    - 2.32.6
-    - 2.32.8
-    - 2.32.9
-  - dependency-name: gatsby-plugin-typescript
-    versions:
-    - 2.11.0
-    - 2.12.0
-  - dependency-name: gatsby-source-filesystem
-    versions:
-    - 2.10.0
-    - 2.11.0
-  - dependency-name: gatsby-transformer-remark
-    versions:
-    - 2.15.0
-    - 2.16.0
-  - dependency-name: gatsby-remark-images
-    versions:
-    - 3.10.0
-    - 3.11.0
-  - dependency-name: gatsby-plugin-google-analytics
-    versions:
-    - 2.10.0
-  - dependency-name: gatsby-remark-autolink-headers
-    versions:
-    - 2.10.0
-  - dependency-name: node-notifier
-    versions:
-    - 8.0.1
+  # GitHub Actions — weekly security check
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - iray-tno
+
+  # Root (legacy Gatsby) — monthly version, weekly security
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      day: 1
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - iray-tno
+    groups:
+      gatsby:
+        patterns:
+          - "gatsby*"
+      redux:
+        patterns:
+          - "redux"
+          - "react-redux"
+          - "@reduxjs/*"
+
+  # Blog app — monthly version, weekly security
+  - package-ecosystem: npm
+    directory: "/apps/blog"
+    schedule:
+      interval: monthly
+      day: 1
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - iray-tno
+    groups:
+      next:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      rehype-remark:
+        patterns:
+          - "rehype*"
+          - "remark*"
+          - "unified"
+          - "hast*"
+          - "mdast*"
+
+  # Components package — monthly version, weekly security
+  - package-ecosystem: npm
+    directory: "/packages/components"
+    schedule:
+      interval: monthly
+      day: 1
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - iray-tno
+    groups:
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"


### PR DESCRIPTION
## Summary

- Switch from daily → monthly version updates (AI agents handle routine upgrades; Dependabot is the safety net)
- Add weekly schedule for GitHub Actions ecosystem (fast CVE response)
- Expand coverage to all workspace dirs: `/`, `/apps/blog`, `/packages/components`
- Group related packages into single PRs per workspace
- Remove stale Gatsby-specific version ignore rules

## Groups configured

| Workspace | Groups |
|-----------|--------|
| `/` | `gatsby*`, `redux` |
| `/apps/blog` | `next`, `react`, `rehype/remark` |
| `/packages/components` | `storybook`, `testing`, `react` |

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML
- [ ] Verify Dependabot picks up all 4 configs in GitHub Security → Dependabot settings

Closes #979
Ref #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)