### PR TITLE
#992 Replace <img> with Next.js <Image> for CLS fix

### DIFF
--- a/apps/blog/app/posts/[slug]/page.tsx
+++ b/apps/blog/app/posts/[slug]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type React from 'react';
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
+import rehypeImgSize from 'rehype-img-size';
 import rehypePrettyCode from 'rehype-pretty-code';
 import rehypeReact from 'rehype-react';
 import remarkParse from 'remark-parse';
@@ -49,6 +50,7 @@ async function renderMarkdown(content: string): Promise<React.JSX.Element> {
   const result = await unified()
     .use(remarkParse)
     .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeImgSize, { dir: 'public' })
     .use(rehypePrettyCode, {
       theme: {
         dark: 'github-dark',

--- a/apps/blog/components/MarkdownImage.tsx
+++ b/apps/blog/components/MarkdownImage.tsx
@@ -7,6 +7,8 @@ interface MarkdownImageProps {
   title?: string;
   caption?: string;
   className?: string;
+  width?: number | string;
+  height?: number | string;
 }
 
 export const MarkdownImage: React.FC<MarkdownImageProps> = ({
@@ -15,16 +17,22 @@ export const MarkdownImage: React.FC<MarkdownImageProps> = ({
   title,
   caption,
   className,
+  width,
+  height,
 }) => {
   if (!src) return null;
+
+  const hasSize = width && height;
+  const imgWidth = hasSize ? Number(width) : 0;
+  const imgHeight = hasSize ? Number(height) : 0;
 
   const img = (
     <NextImage
       src={src}
       alt={alt || ''}
       title={title}
-      width={0}
-      height={0}
+      width={imgWidth}
+      height={imgHeight}
       sizes="100vw"
       className={`w-full h-auto rounded-lg ${className || ''}`}
     />

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -21,6 +21,7 @@
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "rehype-img-size": "^1.0.1",
     "rehype-pretty-code": "^0.14.3",
     "rehype-react": "^8.0.0",
     "remark-parse": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "next": "16.1.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "rehype-img-size": "^1.0.1",
         "rehype-pretty-code": "^0.14.3",
         "rehype-react": "^8.0.0",
         "remark-parse": "^11.0.0",
@@ -21522,6 +21523,21 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/immer": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
@@ -32134,6 +32150,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -32969,6 +32994,61 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/rehype-img-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-img-size/-/rehype-img-size-1.0.1.tgz",
+      "integrity": "sha512-+rLkxF2H3mQULAg3iA2Z2spJQlBcCpApG8sHC47bc0p33ol+ddz+O3gyUcTgk5xX5jGaj1oQOBs/cBy8nIIhoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "image-size": "^1.0.0",
+        "unist-util-visit": "^4.1.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/rehype-img-size/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-img-size/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-img-size/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-parse": {


### PR DESCRIPTION
## Summary

Fixes CLS (Cumulative Layout Shift) for images in blog posts by combining `rehype-img-size` (real dimensions at build time) with Next.js `<Image>`.

## Changes

### Pipeline
- Add `rehype-img-size` to the unified pipeline — reads local image files during build and injects real `width`/`height` into the AST before React rendering

### Components
- Add `apps/blog/components/MarkdownImage.tsx` — uses `next/image` with actual dimensions when available, falls back to `width=0 height=0` gracefully
- Wire `MarkdownImage` into rehype-react pipeline in `app/posts/[slug]/page.tsx`
- Keep `@chirashi/components` framework-agnostic (no `next` dependency)

### How it works

```
Markdown
  → remark-parse
  → remark-rehype
  → rehype-img-size  ← reads public/img/... and injects real w/h
  → rehype-pretty-code
  → rehype-react
  → MarkdownImage (next/image with real dimensions = true CLS fix)
```

When images are migrated to `apps/blog/public/`, `rehype-img-size` will automatically read their dimensions. Until then it falls back gracefully to `width=0 height=0`.

## Commits

1. `#992` Replace `<img>` with Next.js `<Image>` for CLS fix
2. `#992` Add rehype-img-size to inject real dimensions into img AST nodes

## Test plan

- [ ] `npm run build --workspace=blog` succeeds
- [ ] Post pages with images render correctly
- [ ] Once images are in `apps/blog/public/img/`, verify layout shift is gone

Closes #992
Ref #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)