### PR TITLE
#994 Fix N+1 file reads in lib/posts.ts with module-level cache

### DIFF
--- a/apps/blog/lib/posts.ts
+++ b/apps/blog/lib/posts.ts
@@ -33,9 +33,12 @@ function parseFilename(
   return { date: match[1], slug: `${match[1]}_${match[2]}` };
 }
 
-export function getAllPosts(): Post[] {
-  const files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith('.md'));
+let cachedPosts: Post[] | null = null;
 
+export function getAllPosts(): Post[] {
+  if (cachedPosts) return cachedPosts;
+
+  const files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith('.md'));
   const posts: Post[] = [];
 
   for (const file of files) {
@@ -60,7 +63,8 @@ export function getAllPosts(): Post[] {
 
   posts.sort((a, b) => b.date.localeCompare(a.date));
 
-  return posts;
+  cachedPosts = posts;
+  return cachedPosts;
 }
 
 export interface PostWithContent extends Post {


### PR DESCRIPTION
## Summary

Every derived function (`getAllCategories`, `getAllTags`, `getPostsByCategory`, `getPostsByTag`, `getAllSlugs`) was independently calling `getAllPosts()` which re-reads all 35 markdown files from disk each time. The tags index page alone triggered 20+ full directory scans at build time.

## Fix

Add a module-level `cachedPosts` variable. `getAllPosts()` reads files once per process and caches the result. All derived functions share that cache — no API changes for consumers.

## Impact

| Page | File reads before | File reads after |
|------|------------------|-----------------|
| `/tags` | ~700 (20 tags × 35 posts) | 35 |
| `/categories` | ~175 (5 categories × 35 posts) | 35 |
| `/posts/[slug]` | 35 (separate `getPostBySlug`) | 35 (unchanged) |

## Change

```diff
+ let cachedPosts: Post[] | null = null;

  export function getAllPosts(): Post[] {
+   if (cachedPosts) return cachedPosts;
    // ... read files ...
+   cachedPosts = posts;
    return posts;
  }
```

6 lines changed, zero API changes.

## Test plan

- [ ] `npm run build --workspace=blog` succeeds
- [ ] All post, category, and tag pages render correctly

Closes #994
Ref #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)