### PR TITLE
#1006 Add frontmatter validation at build time

### DIFF
--- a/apps/blog/lib/posts.test.ts
+++ b/apps/blog/lib/posts.test.ts
@@ -164,6 +164,47 @@ describe('getPostsByTag', () => {
   });
 });
 
+describe('frontmatter validation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    'title',
+    'author',
+    'category',
+  ] as const)('throws when "%s" is missing', async (field) => {
+    const broken = MOCK_POST_MD.replace(
+      new RegExp(`${field}: [^\n]+`),
+      `${field}: ''`
+    );
+    setupFsMock({ '2024-01-15_01_broken.md': broken });
+
+    const { getAllPosts } = await import('./posts');
+    expect(() => getAllPosts()).toThrow(/missing or empty/);
+  });
+
+  it('throws when tags is not an array', async () => {
+    const broken = MOCK_POST_MD.replace(
+      "tags: [Python, '競プロ(CompProg)']",
+      'tags: not-an-array'
+    );
+    setupFsMock({ '2024-01-15_01_broken.md': broken });
+
+    const { getAllPosts } = await import('./posts');
+    expect(() => getAllPosts()).toThrow(/"tags" must be an array/);
+  });
+
+  it('includes the filename in the error message', async () => {
+    const broken = MOCK_POST_MD.replace('title: Test Post', "title: ''");
+    setupFsMock({ '2024-01-15_01_broken.md': broken });
+
+    const { getAllPosts } = await import('./posts');
+    expect(() => getAllPosts()).toThrow('2024-01-15_01_broken.md');
+  });
+});
+
 describe('getPostsByCategory', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/blog/lib/posts.ts
+++ b/apps/blog/lib/posts.ts
@@ -24,6 +24,7 @@ interface PostFrontmatter {
 }
 
 const FILENAME_REGEX = /^(\d{4}-\d{2}-\d{2})_\d{2}_(.+)\.md$/;
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 function parseFilename(
   filename: string
@@ -31,6 +32,37 @@ function parseFilename(
   const match = filename.match(FILENAME_REGEX);
   if (!match) return null;
   return { date: match[1], slug: `${match[1]}_${match[2]}` };
+}
+
+function validateFrontmatter(
+  filename: string,
+  data: PostFrontmatter,
+  date: string
+): void {
+  const errors: string[] = [];
+
+  if (!data.title || typeof data.title !== 'string' || data.title.trim() === '')
+    errors.push('missing or empty "title"');
+  if (
+    !data.author ||
+    typeof data.author !== 'string' ||
+    data.author.trim() === ''
+  )
+    errors.push('missing or empty "author"');
+  if (
+    !data.category ||
+    typeof data.category !== 'string' ||
+    data.category.trim() === ''
+  )
+    errors.push('missing or empty "category"');
+  if (!Array.isArray(data.tags)) errors.push('"tags" must be an array');
+  if (!DATE_REGEX.test(date)) errors.push(`invalid date format "${date}"`);
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Frontmatter validation failed for "${filename}":\n  - ${errors.join('\n  - ')}`
+    );
+  }
 }
 
 let cachedPosts: Post[] | null = null;
@@ -50,6 +82,8 @@ export function getAllPosts(): Post[] {
     const frontmatter = data as PostFrontmatter;
 
     if (frontmatter.publish === false) continue;
+
+    validateFrontmatter(file, frontmatter, parsed.date);
 
     posts.push({
       slug: parsed.slug,
@@ -83,6 +117,8 @@ export function getPostBySlug(slug: string): PostWithContent | null {
     const frontmatter = data as PostFrontmatter;
 
     if (frontmatter.publish === false) return null;
+
+    validateFrontmatter(file, frontmatter, parsed.date);
 
     return {
       slug: parsed.slug,


### PR DESCRIPTION
## Summary

Closes out #996 item I. Posts with missing or malformed frontmatter now throw a descriptive error at build time instead of silently rendering broken pages.

## Changes

### `apps/blog/lib/posts.ts`
- Added `validateFrontmatter(filename, data, date)` that checks:
  - `title`, `author`, `category` — must be present, non-empty strings
  - `tags` — must be an array
  - `date` — must match `YYYY-MM-DD` format
- Called in both `getAllPosts` and `getPostBySlug` (after `publish: false` skip)
- Error message includes filename and lists all failures, e.g.:
  ```
  Frontmatter validation failed for "2024-01-15_01_bad.md":
    - missing or empty "title"
    - "tags" must be an array
  ```

### `apps/blog/lib/posts.test.ts`
- 5 new tests: missing title/author/category, tags not an array, filename in error

## Test Results
- ✅ 18/18 blog tests pass
- ✅ Blog builds successfully against all existing content
- ✅ Biome check clean

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)