### PR TITLE
#1010 Auto-build components before blog build/dev

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "copy-images": "mkdir -p public/img && cp -r ../../packages/content/images/* public/img/",
-    "predev": "npm run copy-images",
+    "predev": "npm run copy-images && npm run build --workspace=@chirashi/components",
     "dev": "next dev",
-    "prebuild": "npm run copy-images",
+    "prebuild": "npm run copy-images && npm run build --workspace=@chirashi/components",
     "build": "next build",
     "start": "next start",
     "lint": "biome lint app lib",


### PR DESCRIPTION
## Problem

`npm run build --workspace=blog` (or `npm run build` at root) fails on a fresh clone with:
```
Module not found: Can't resolve '@chirashi/components/markdown'
Module not found: Can't resolve '@chirashi/components/ui'
```
because `packages/components/dist/` doesn't exist until components are built.

## Fix

Add `npm run build --workspace=@chirashi/components` to the blog's `prebuild` and `predev` hooks so it always runs first automatically.

## Test Results
- ✅ Verified: deleted `dist/`, ran `npm run build --workspace=blog` — components auto-built, blog built successfully
- ✅ Biome check clean

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)