### PR TITLE
#1031 Enable full static export

### DIFF
--- a/apps/blog/app/feed.xml/route.test.ts
+++ b/apps/blog/app/feed.xml/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs');
+
+import * as fs from 'node:fs';
+
+const MOCK_POST = `---
+title: Hello World
+author: Alice
+category: Tech
+tags: ['Python']
+---
+Body text.
+`;
+
+function setupFsMock(files: Record<string, string>) {
+  vi.mocked(fs.readdirSync).mockReturnValue(
+    Object.keys(files) as unknown as ReturnType<typeof fs.readdirSync>
+  );
+  vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+    const name = String(filePath).split('/').pop() ?? '';
+    if (name in files) return files[name];
+    throw new Error(`ENOENT: ${filePath}`);
+  });
+}
+
+describe('feed.xml route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('exports force-static for static export compatibility', async () => {
+    setupFsMock({});
+    const { dynamic } = await import('./route');
+    expect(dynamic).toBe('force-static');
+  });
+
+  it('returns application/rss+xml content-type', async () => {
+    setupFsMock({ '2024-01-15_01_hello-world.md': MOCK_POST });
+    const { GET } = await import('./route');
+    const response = await GET();
+    expect(response.headers.get('Content-Type')).toMatch('application/rss+xml');
+  });
+
+  it('returns valid RSS XML with channel and items', async () => {
+    setupFsMock({ '2024-01-15_01_hello-world.md': MOCK_POST });
+    const { GET } = await import('./route');
+    const response = await GET();
+    const xml = await response.text();
+
+    expect(xml).toMatch(/^<\?xml/);
+    expect(xml).toContain('<rss');
+    expect(xml).toContain('<channel>');
+    expect(xml).toContain('<item>');
+    expect(xml).toContain('Hello World');
+    expect(xml).toContain('Alice');
+  });
+});

--- a/apps/blog/app/feed.xml/route.ts
+++ b/apps/blog/app/feed.xml/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-static';
+
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';

--- a/apps/blog/app/robots.test.ts
+++ b/apps/blog/app/robots.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import robots, { dynamic } from './robots';
+
+describe('robots', () => {
+  it('exports force-static for static export compatibility', () => {
+    expect(dynamic).toBe('force-static');
+  });
+
+  it('allows all user agents', () => {
+    const result = robots();
+    expect(result.rules).toMatchObject({ userAgent: '*', allow: '/' });
+  });
+
+  it('includes sitemap URL', () => {
+    const result = robots();
+    expect(result.sitemap).toMatch(/sitemap\.xml$/);
+  });
+});

--- a/apps/blog/app/robots.ts
+++ b/apps/blog/app/robots.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-static';
+
 import type { MetadataRoute } from 'next';
 import { SITE_URL } from '@/lib/config';
 

--- a/apps/blog/app/sitemap.test.ts
+++ b/apps/blog/app/sitemap.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs');
+
+import * as fs from 'node:fs';
+
+const MOCK_POST = `---
+title: Hello World
+author: Alice
+category: Tech
+tags: []
+---
+Body.
+`;
+
+function setupFsMock(files: Record<string, string>) {
+  vi.mocked(fs.readdirSync).mockReturnValue(
+    Object.keys(files) as unknown as ReturnType<typeof fs.readdirSync>
+  );
+  vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+    const name = String(filePath).split('/').pop() ?? '';
+    if (name in files) return files[name];
+    throw new Error(`ENOENT: ${filePath}`);
+  });
+}
+
+describe('sitemap', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('exports force-static for static export compatibility', async () => {
+    setupFsMock({});
+    const { dynamic } = await import('./sitemap');
+    expect(dynamic).toBe('force-static');
+  });
+
+  it('includes static pages and post entries', async () => {
+    setupFsMock({ '2024-01-15_01_hello-world.md': MOCK_POST });
+    const { default: sitemap } = await import('./sitemap');
+    const entries = sitemap();
+    const urls = entries.map((e) => e.url);
+
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/nobody\.jp$/),
+        expect.stringMatching(/\/categories$/),
+        expect.stringMatching(/\/tags$/),
+        expect.stringMatching(/\/posts\/2024-01-15_hello-world$/),
+      ])
+    );
+  });
+
+  it('sets lastModified from post date', async () => {
+    setupFsMock({ '2024-01-15_01_hello-world.md': MOCK_POST });
+    const { default: sitemap } = await import('./sitemap');
+    const entries = sitemap();
+    const post = entries.find((e) => e.url.includes('/posts/'));
+
+    expect(post?.lastModified).toEqual(new Date('2024-01-15'));
+  });
+});

--- a/apps/blog/app/sitemap.ts
+++ b/apps/blog/app/sitemap.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-static';
+
 import type { MetadataRoute } from 'next';
 import { SITE_URL } from '@/lib/config';
 import { getAllPosts } from '@/lib/posts';

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'export',
 };
 
 export default nextConfig;

--- a/apps/blog/vitest.config.ts
+++ b/apps/blog/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
## Summary
Converts all dynamic routes to static and enables `output: 'export'` in Next.js config. The blog now produces a fully static `out/` directory at build time, ready for S3+CloudFront hosting (prerequisite for #1030).

## Changes
- ✅ `app/feed.xml/route.ts` — add `export const dynamic = 'force-static'`
- ✅ `app/robots.ts` — add `export const dynamic = 'force-static'`
- ✅ `app/sitemap.ts` — add `export const dynamic = 'force-static'`
- ✅ `next.config.ts` — add `output: 'export'`

## Build output (before → after)
```
ƒ /feed.xml   →   ○ /feed.xml
○ /robots.txt  →   ○ /robots.txt  (was already static, needed directive)
○ /sitemap.xml →   ○ /sitemap.xml (was already static, needed directive)
```
No `ƒ` (dynamic) routes remain.

## Test Results
- ✅ Blog builds successfully, all routes static

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)